### PR TITLE
Add additional indicators and modality summaries

### DIFF
--- a/code/03_construct_indices.do
+++ b/code/03_construct_indices.do
@@ -90,6 +90,87 @@ if _rc {
     }
 }
 
+* ===== LCS =====
+capture confirm variable LCS
+if _rc {
+    local stress "Lcs_stress_DomAsset Lcs_stress_HealthEdu Lcs_stress_Saving Lcs_stress_BorrowCash LcsEN_stress_DomAsset LcsEN_stress_HealthEdu LcsEN_stress_Saving LcsEN_stress_BorrowCash"
+    local crisis "Lcs_crisis_ProdAssets Lcs_crisis_DomMigration Lcs_crisis_ChildWork LcsEN_crisis_ProdAssets LcsEN_crisis_DomMigration LcsEN_crisis_ChildWork"
+    local emergency "Lcs_em_ResAsset Lcs_em_Begged Lcs_em_FemAnimal LcsEN_em_ResAsset LcsEN_em_Begged LcsEN_em_FemAnimal"
+    gen byte LCS = 0
+    local found_any 0
+    foreach v of local stress {
+        capture confirm variable `v'
+        if !_rc {
+            replace LCS = max(LCS, 1*(`v'==1)) if !missing(`v')
+            local found_any 1
+        }
+    }
+    foreach v of local crisis {
+        capture confirm variable `v'
+        if !_rc {
+            replace LCS = max(LCS, 2*(`v'==1)) if !missing(`v')
+            local found_any 1
+        }
+    }
+    foreach v of local emergency {
+        capture confirm variable `v'
+        if !_rc {
+            replace LCS = max(LCS, 3*(`v'==1)) if !missing(`v')
+            local found_any 1
+        }
+    }
+    if !`found_any' {
+        replace LCS = .
+    }
+}
+
+* ===== FES =====
+capture confirm variable FES
+if _rc {
+    local cand "FES CARI_FES_Raw FES_Raw FoodExpShare food_exp_share"
+    local chosen ""
+    foreach v of local cand {
+        capture confirm variable `v'
+        if !_rc & "`chosen'"=="" local chosen "`v'"
+    }
+    if "`chosen'" != "" {
+        gen double FES = `chosen'
+    }
+    else {
+        local food_cand "food_exp foodexpenditure FoodExp"
+        local tot_cand "total_exp totalexpenditure exp_total"
+        local food_var ""
+        local tot_var ""
+        foreach v of local food_cand {
+            capture confirm variable `v'
+            if !_rc & "`food_var'"=="" local food_var "`v'"
+        }
+        foreach v of local tot_cand {
+            capture confirm variable `v'
+            if !_rc & "`tot_var'"=="" local tot_var "`v'"
+        }
+        if "`food_var'"!="" & "`tot_var'"!="" {
+            gen double FES = 100*`food_var'/`tot_var'
+        }
+        else gen double FES = .
+    }
+}
+
+* ===== income =====
+capture confirm variable income
+if _rc {
+    local cand "Income_Recode_Cat Income_Recode Income_3pt HHIncome_3pt income"
+    local chosen ""
+    foreach v of local cand {
+        capture confirm variable `v'
+        if !_rc & "`chosen'"=="" local chosen "`v'"
+    }
+    if "`chosen'"!="" {
+        gen double income = `chosen'
+    }
+    else gen double income = .
+}
+
 * ===== HHS =====
 capture confirm variable HHS
 if _rc {

--- a/code/08_indicators.do
+++ b/code/08_indicators.do
@@ -1,5 +1,5 @@
 *******************************************************
-* 08_indicators.do — Binary indicators by mode
+* 08_indicators.do — Indicator summaries by mode
 *******************************************************
 
 version 17
@@ -9,17 +9,23 @@ do "00_utils.do"
 use "$IN_FOR_TABLES", clear
 _mk_label
 
-* Food insecurity indicator
-capture drop food_insecure
-gen byte food_insecure = (FCS < $FCS_CUTOFF) if !missing(FCS)
+local indvars "FCS rCSI LCS FES income"
+tempfile stats
+tempname mem
+postfile `mem' str20 indicator double mean_F2F sd_F2F N_F2F mean_Remote sd_Remote N_Remote tstat using `stats'
 
-preserve
-    collapse (count) N = food_insecure (mean) food_insecure, by($MODE)
-    tostring $MODE, gen(mode_str)
-    replace mode_str = cond($MODE==0, "F2F", "Remote")
-    rename food_insecure prop_food_insecure
-    order mode_str prop_food_insecure N
-    _xlsx_export, sheet("Indicators")
-restore
+foreach v of local indvars {
+    capture confirm variable `v'
+    if !_rc {
+        quietly ttest `v', by($MODE)
+        post `mem' ("`v'") (r(mu_1)) (r(sd_1)) (r(N_1)) (r(mu_2)) (r(sd_2)) (r(N_2)) (r(t))
+    }
+}
+
+postclose `mem'
+use `stats', clear
+order indicator mean_F2F sd_F2F N_F2F mean_Remote sd_Remote N_Remote tstat
+_xlsx_export, sheet("Indicators")
 
 display as result "08_indicators.do complete → Indicators sheet"
+


### PR DESCRIPTION
## Summary
- Compute LCS, FES, and income indicators when absent in dataset
- Summarize FCS, rCSI, LCS, FES, and income by survey mode with t-tests exported to Indicators sheet

## Testing
- `stata-mp -q -b do code/03_construct_indices.do` *(fails: command not found)*
- `stata-mp -q -b do code/08_indicators.do` *(fails: command not found)*
