### PR TITLE
Validate subgroup list and broaden heterogeneity outcomes

### DIFF
--- a/code/00_config.do
+++ b/code/00_config.do
@@ -48,6 +48,31 @@ global WGT ""
 capture macro drop SUBGROUPS
 global SUBGROUPS "head_female urban poor_pre"
 
+* Verify subgroup variables exist in data and are binary (0/1)
+capture noisily {
+    use "$IN_FOR_TABLES", clear
+    local __sg_list "$SUBGROUPS"
+    local __keep ""
+    foreach sg of local __sg_list {
+        capture confirm numeric variable `sg'
+        if _rc {
+            di as error "SUBGROUP `sg' missing or non-numeric; dropping"
+            continue
+        }
+        quietly count if inlist(`sg',0,1)
+        local n01 = r(N)
+        quietly count if !missing(`sg')
+        if r(N)==`n01' & r(N)>0 {
+            local __keep "`__keep' `sg'"
+        }
+        else {
+            di as error "SUBGROUP `sg' not binary 0/1; dropping"
+        }
+    }
+    global SUBGROUPS "`__keep'"
+    clear
+}
+
 * Feature flags
 capture macro drop FLAG_EXPORT
 global FLAG_EXPORT 1

--- a/code/09_heterogeneity.do
+++ b/code/09_heterogeneity.do
@@ -9,17 +9,7 @@ do "00_utils.do"
 use "$IN_FOR_TABLES", clear
 _mk_label
 
-* Guard: need outcome & mode
-capture confirm variable FCS
-if _rc {
-    preserve
-        clear
-        set obs 1
-        gen note = "FCS not found in $IN_FOR_TABLES; skipping heterogeneity."
-        _xlsx_export, sheet("Heterogeneity")
-    restore
-    exit
-}
+* Guard: need mode variable
 capture confirm variable $MODE
 if _rc {
     preserve
@@ -31,83 +21,70 @@ if _rc {
     exit
 }
 
+local outcomes "FCS rCSI FES"
+
 tempfile het
 capture postutil clear
 tempname H
-postfile `H' str32 subgroup str8 level double N coef se pval using "`het'", replace
+postfile `H' str32 outcome str32 subgroup str8 level double N coef se pval using "`het'", replace
 
-foreach sg of global SUBGROUPS {
-    capture confirm variable `sg'
+foreach y of local outcomes {
+    capture confirm variable `y'
     if _rc {
-        post `H' ("`sg' (missing)") ("") (.) (.) (.) (.)
+        post `H' ("`y' (missing)") ("") ("") (.) (.) (.) (.)
         continue
     }
 
-    * Count observations by binary levels (0/1)
-    quietly count if `sg'==1
-    local n1 = r(N)
-    quietly count if `sg'==0
-    local n0 = r(N)
+    foreach sg of global SUBGROUPS {
+        capture confirm variable `sg'
+        if _rc {
+            post `H' ("`y'") ("`sg' (missing)") ("") (.) (.) (.) (.)
+            continue
+        }
 
-    * If both levels have zero obs (all missing or non-binary), record and skip
-    if (`n1'==0 & `n0'==0) {
-        post `H' ("`sg' (no 0/1 values)") ("") (.) (.) (.) (.)
-        continue
+        quietly count if `sg'==0 & !missing(`y',`sg')
+        local N0 = r(N)
+        quietly count if `sg'==1 & !missing(`y',`sg')
+        local N1 = r(N)
+        if (`N0'==0 & `N1'==0) {
+            post `H' ("`y'") ("`sg' (no 0/1 values)") ("") (.) (.) (.) (.)
+            continue
+        }
+
+        capture noisily _regw regress `y' i.$MODE##i.`sg'
+        if (_rc) {
+            post `H' ("`y'") ("`sg'") ("0") (`N0') (.) (.) (.)
+            post `H' ("`y'") ("`sg'") ("1") (`N1') (.) (.) (.)
+        }
+        else {
+            * Effect for subgroup level 0
+            lincom 1.$MODE
+            scalar b = r(estimate)
+            scalar s = r(se)
+            scalar p = .
+            capture confirm scalar s
+            if !_rc & s>0 {
+                scalar p = 2*ttail(r(df), abs(b/s))
+            }
+            post `H' ("`y'") ("`sg'") ("0") (`N0') (b) (s) (p)
+
+            * Effect for subgroup level 1
+            lincom 1.$MODE + 1.$MODE#1.`sg'
+            scalar b = r(estimate)
+            scalar s = r(se)
+            scalar p = .
+            capture confirm scalar s
+            if !_rc & s>0 {
+                scalar p = 2*ttail(r(df), abs(b/s))
+            }
+            post `H' ("`y'") ("`sg'") ("1") (`N1') (b) (s) (p)
+        }
     }
-
-    * ---------- Level 1 ----------
-    preserve
-        keep if `sg'==1
-        local N_here = _N
-        if (`N_here'==0) {
-            post `H' ("`sg'") ("1") (0) (.) (.) (.)
-        }
-        else {
-            capture noisily _regw regress FCS i.$MODE
-            if (_rc) {
-                post `H' ("`sg'") ("1") (`N_here') (.) (.) (.)
-            }
-            else {
-                capture scalar b = _b[1.$MODE]
-                capture scalar s = _se[1.$MODE]
-                capture scalar p = .
-                capture confirm scalar s
-                if !_rc & s>0 {
-                    scalar p = 2*ttail(e(df_r), abs(b/s))
-                }
-                post `H' ("`sg'") ("1") (e(N)) (b) (s) (p)
-            }
-        }
-    restore
-
-    * ---------- Level 0 ----------
-    preserve
-        keep if `sg'==0
-        local N_here = _N
-        if (`N_here'==0) {
-            post `H' ("`sg'") ("0") (0) (.) (.) (.)
-        }
-        else {
-            capture noisily _regw regress FCS i.$MODE
-            if (_rc) {
-                post `H' ("`sg'") ("0") (`N_here') (.) (.) (.)
-            }
-            else {
-                capture scalar b = _b[1.$MODE]
-                capture scalar s = _se[1.$MODE]
-                capture scalar p = .
-                capture confirm scalar s
-                if !_rc & s>0 {
-                    scalar p = 2*ttail(e(df_r), abs(b/s))
-                }
-                post `H' ("`sg'") ("0") (e(N)) (b) (s) (p)
-            }
-        }
-    restore
 }
 
 postclose `H'
 use "`het'", clear
+label var outcome  "Outcome"
 label var subgroup "Subgroup"
 label var level    "Level"
 label var N        "N"
@@ -118,3 +95,4 @@ label var pval     "p-value"
 _xlsx_export, sheet("Heterogeneity")
 
 display as result "09_heterogeneity.do complete → Heterogeneity sheet"
+


### PR DESCRIPTION
## Summary
- Verify candidate subgroup variables are present and binary before use
- Analyze modality effects for FCS, rCSI, and FES outcomes with interaction terms

## Testing
- `stata -b do code/09_heterogeneity.do` *(fails: command not found)*
