### PR TITLE
Centralize regression utilities and Excel export

### DIFF
--- a/code_v2/00_utils.do
+++ b/code_v2/00_utils.do
@@ -42,6 +42,21 @@ program define _mk_label
 end
 
 * ----------------------------------------------------
+* _regw — run command with pweight=$WGT if defined
+* ----------------------------------------------------
+capture program drop _regw
+program define _regw
+    version 17
+    syntax anything
+    if "$WGT" != "" {
+        `anything' [pweight=$WGT]
+    }
+    else {
+        `anything'
+    }
+end
+
+* ----------------------------------------------------
 * _xlsx_export — robust Excel exporter
 *   - Creates workbook/dir if missing
 *   - Checks whether sheet exists and chooses replace vs create

--- a/code_v2/02_clean_bf.do
+++ b/code_v2/02_clean_bf.do
@@ -7,54 +7,6 @@ set more off
 
 do "00_utils.do"
 
-* ---- NEW: run command with weights only if $WGT is set (helper, safe to keep) ----
-capture program drop _regw
-program define _regw
-    version 17
-    syntax anything
-    if "$WGT" != "" {
-        `anything' [pweight=$WGT]
-    }
-    else {
-        `anything'
-    }
-end
-* -----------------------------------------------------------
-
-* (These are harmless if duplicated across files.)
-capture program drop _xlsx_export
-program define _xlsx_export
-    // Export current dataset to Excel sheet, preserving other sheets
-    // Usage: _xlsx_export , sheet("SheetName")
-    syntax , Sheet(string)
-    local file "$OUT_XLSX"
-    capture confirm file "`file'"
-    if _rc {
-        export excel using "`file'", sheet("`sheet'") firstrow(variables) replace
-    }
-    else {
-        export excel using "`file'", sheet("`sheet'", replace) firstrow(variables)
-    }
-end
-
-capture program drop _sheet_exists
-program define _sheet_exists, rclass
-    // Return r(found)=1 if sheet exists in $OUT_XLSX, else 0
-    syntax , Sheet(string)
-    tempfile __s
-    capture noisily import excel using "$OUT_XLSX", describe clear
-    if _rc {
-        return scalar found = 0
-        exit
-    }
-    local sheets = r(worksheetlist)
-    local found 0
-    foreach s of local sheets {
-        if "`s'" == "`sheet'" local found 1
-    }
-    return scalar found = `found'
-end
-
 * ----------------------------------------------------
 * 1) Load the best available input
 * ----------------------------------------------------

--- a/code_v2/06_balance.do
+++ b/code_v2/06_balance.do
@@ -10,7 +10,7 @@ version 17
 set more off
 
 * Always load helpers
-do "$CODE/00_utils.do"
+do "00_utils.do"
 
 * Pick dataset (prefer the one with indices and both modes)
 capture confirm file "$IN_FOR_TABLES"

--- a/code_v2/10_quality_checks.do
+++ b/code_v2/10_quality_checks.do
@@ -6,32 +6,6 @@ version 17
 set more off
 do "00_utils.do"
 
-* Helpers (safe if duplicated)
-capture program drop _regw
-program define _regw
-    version 17
-    syntax anything
-    if "$WGT" != "" {
-        `anything' [pweight=$WGT]
-    }
-    else {
-        `anything'
-    }
-end
-
-capture program drop _xlsx_export
-program define _xlsx_export
-    syntax , Sheet(string)
-    local file "$OUT_XLSX"
-    capture confirm file "`file'"
-    if _rc {
-        export excel using "`file'", sheet("`sheet'") firstrow(variables) replace
-    }
-    else {
-        export excel using "`file'", sheet("`sheet'", replace) firstrow(variables)
-    }
-end
-
 use "$OUT_CLEAN", clear
 _mk_label
 

--- a/code_v2/11_enumerator_robustness.do
+++ b/code_v2/11_enumerator_robustness.do
@@ -7,20 +7,6 @@ set more off
 
 do "00_utils.do"
 
-* ---- Weighted runner (uses $WGT only if set) ----
-capture program drop _regw
-program define _regw
-    version 17
-    syntax anything
-    if "$WGT" != "" {
-        `anything' [pweight=$WGT]
-    }
-    else {
-        `anything'
-    }
-end
-* --------------------------------------------------
-
 * Prefer the dataset with indices if it exists (FCS/rCSI/HHS), else cleaned
 capture confirm file "$IN_FOR_TABLES"
 if !_rc {


### PR DESCRIPTION
## Summary
- Add `_regw` weight-aware wrapper to shared utilities.
- Remove duplicated `_regw` and `_xlsx_export` implementations from module scripts.
- Standardize module scripts to load `00_utils.do` for shared helpers.

## Testing
- `stata -q do code_v2/00_utils.do` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c20dfa9e3483319dc3367e4e9ec92d