### PR TITLE
Handle missing FCS components without errors

### DIFF
--- a/code_v2/03_construct_indices.do
+++ b/code_v2/03_construct_indices.do
@@ -45,7 +45,7 @@ if _rc {
             gen double ``_`k''' = .
             capture confirm variable `v_`k''
             if !_rc {
-                gen double ``_`k''' = max(0, min(7, `v_`k''))
+                replace ``_`k''' = max(0, min(7, `v_`k''))
             }
             else replace ``_`k''' = 0
         }


### PR DESCRIPTION
## Summary
- Replace inner `gen` with `replace` when computing capped FCS components.

## Testing
- `stata -b do code_v2/03_construct_indices.do` *(fails: command not found)*
